### PR TITLE
Update scraping_basics.ipynb - add missing > to style tag in simple_html

### DIFF
--- a/PyCon_2020/scraping_basics.ipynb
+++ b/PyCon_2020/scraping_basics.ipynb
@@ -89,7 +89,7 @@
     "<head>\n",
     "  <style>\n",
     "    li {font-size: 18px;}\n",
-    "  </style\n",
+    "  </style>\n",
     "</head>\n",
     "\n",
     "<body>\n",


### PR DESCRIPTION
adding a > to the closing style tag in the simple_html string (line 92), this allows BeautifulSoup to parse the string in the next cells